### PR TITLE
Add deleted_at to soft delete comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
   before_action :redirect_cancel, :only => [:update]
   
   def index
-    @comment = @story.comments.all
+    @comment = @story.comments.active
   end
   
   def create
@@ -12,7 +12,7 @@ class CommentsController < ApplicationController
       flash[:warning] = "Please sign in to continue"
       redirect_to new_user_session_path
     else
-      @comment = @story.comments.build(comment_params)
+      @comment = @story.comments.active.build(comment_params)
       @comment.user = current_user    
       respond_to do |format|
         if @comment.save
@@ -59,7 +59,8 @@ class CommentsController < ApplicationController
       flash[:alert] = "You can only edit your own comments"
       redirect_to story_path(@story)
     else
-      if @comment.destroy
+      @comment.deleted_at = DateTime.now
+      if @comment.save
         destroy_notification(@comment)
         flash[:success] = "Comment has been deleted"
         redirect_to story_path(@story)
@@ -98,7 +99,7 @@ class CommentsController < ApplicationController
     end
     #get array of id's of other users who commented
     user_array = []
-    Story.find(comment.story_id).comments.each do |existingcomment|
+    Story.find(comment.story_id).comments.active.each do |existingcomment|
       unless comment.user_id == existingcomment.user_id || existingcomment.user_id == story.author_id
         user_array.push(existingcomment.user_id)
       end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -90,7 +90,7 @@ class DashboardController < ApplicationController
   end
   
   def set_commented_stories
-    @commented_stories = Story.active.joins(:comments).where(:comments => { :user_id => @user.id})
+    @commented_stories = Story.active.joins(:comments).where(:comments => { :user_id => @user.id, :deleted_at => nil})
   end
   
   def set_followers

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -37,7 +37,7 @@ class StoriesController < ApplicationController
   end
   
   def show
-    @comment = @story.comments.build
+    @comment = @story.comments.active.build
     @bookmark = @story.bookmarks.build
   end
   

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,6 @@ class Comment < ApplicationRecord
   belongs_to :user
   
   validates :body, presence: true
+  
+  scope :active, -> { where(deleted_at: nil) }
 end

--- a/app/views/comments/_show.html.slim
+++ b/app/views/comments/_show.html.slim
@@ -1,5 +1,5 @@
 h2 Comments
-- persisted_comments = @story.comments.reject { |comment| comment.new_record? }
+- persisted_comments = @story.comments.active.reject { |comment| comment.new_record? }
 - if persisted_comments.any?
   - persisted_comments.each do |comment|
     div id="comment_#{comment.id}"

--- a/db/migrate/20161122200520_add_deleted_at_to_comments.rb
+++ b/db/migrate/20161122200520_add_deleted_at_to_comments.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToComments < ActiveRecord::Migration[5.0]
+  def change
+    add_column :comments, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161119003442) do
+ActiveRecord::Schema.define(version: 20161122200520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20161119003442) do
     t.integer  "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["story_id"], name: "index_comments_on_story_id", using: :btree
     t.index ["user_id"], name: "index_comments_on_user_id", using: :btree
   end


### PR DESCRIPTION
Implemented soft delete comments by adding deleted_at to the Comment model and added a scope 'active' to comment.rb and made the necessary corresponding changes. 