### PR TITLE
Remove search_param from SearchQueryLogs and refactor stories_controller

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -10,17 +10,9 @@ class StoriesController < ApplicationController
     if params[:search]
       @results = (Story.includes(:user).search params[:search], operator: "or")
       @stories = @results.results
-      log_search_query(params[:search], @results.count , "search")
+      log_search_query(params[:search], @results.count)
       if @results.count <=0
         flash[:warning] = "No stories matched : "+ params[:search]
-        redirect_to root_path
-      end
-    elsif params[:search_tag]
-      @results = (Story.search params[:search_tag], fields: [{tags: :exact}])
-      @stories = @results.results
-      log_search_query(params[:search_tag], @results.count , "search_tag")
-      if @results.count <=0
-        flash[:warning] = "No stories matched : "+ params[:search_tag]
         redirect_to root_path
       end
     elsif params[:search_tag]
@@ -173,13 +165,13 @@ class StoriesController < ApplicationController
     end
   end
   
-  def log_search_query(query_string, result_count, search_param)
+  def log_search_query(query_string, result_count)
     if current_user
       user_id = current_user.id
     else
       user_id = nil
     end
-    SearchQueryLog.create(query_string: query_string, result_count: result_count, search_param: search_param, user_id: user_id)
+    SearchQueryLog.create(query_string: query_string, result_count: result_count, user_id: user_id)
   end
     
   def set_tags

--- a/db/migrate/20170117202822_remove_search_param_from_search_query_log.rb
+++ b/db/migrate/20170117202822_remove_search_param_from_search_query_log.rb
@@ -1,0 +1,5 @@
+class RemoveSearchParamFromSearchQueryLog < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :search_query_logs, :search_param, :string
+  end
+end


### PR DESCRIPTION
Removed search_param from SearchQueryLogs and refactored stories_controller to remove the logging for filtering stories by tags through the navbar